### PR TITLE
MI5-65 Implementacija pregleda svih korisničkih računa + pretraživanje korisničkih računa

### DIFF
--- a/app/src/main/java/foi/air/szokpt/models/ListedAccountInformation.kt
+++ b/app/src/main/java/foi/air/szokpt/models/ListedAccountInformation.kt
@@ -1,0 +1,14 @@
+package foi.air.szokpt.models
+
+enum class AccountListRole {
+    User,
+    Admin
+}
+
+data class ListedAccountInformation(
+    val name: String,
+    val lastName: String,
+    val userName: String,
+    // TODO: Change to actual type of Role, not this enum class above
+    val role: AccountListRole // Need to change to actual type of Role! This is temporary for proof of concept!
+)

--- a/app/src/main/java/foi/air/szokpt/ui/components/list_components/AccountListItem.kt
+++ b/app/src/main/java/foi/air/szokpt/ui/components/list_components/AccountListItem.kt
@@ -1,0 +1,50 @@
+package foi.air.szokpt.ui.components.list_components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import foi.air.szokpt.models.ListedAccountInformation
+import foi.air.szokpt.ui.theme.BGLevelThree
+import foi.air.szokpt.ui.theme.TextGray
+import foi.air.szokpt.ui.theme.TextWhite
+
+@Composable
+fun AccountListItem(account: ListedAccountInformation) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp, horizontal = 6.dp)
+            .background(
+                color = BGLevelThree,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .clickable { println("Selected account: $account") } // Forward HERE
+            .padding(6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(
+                text = account.role.name + " @" + account.userName,
+                color = TextGray,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "${account.name} ${account.lastName}",
+                color = TextWhite,
+                fontSize = 16.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/foi/air/szokpt/ui/components/list_components/AccountListItem.kt
+++ b/app/src/main/java/foi/air/szokpt/ui/components/list_components/AccountListItem.kt
@@ -11,11 +11,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import foi.air.szokpt.models.ListedAccountInformation
 import foi.air.szokpt.ui.theme.BGLevelThree
+import foi.air.szokpt.ui.theme.Primary
+import foi.air.szokpt.ui.theme.Secondary
 import foi.air.szokpt.ui.theme.TextGray
 import foi.air.szokpt.ui.theme.TextWhite
 
@@ -36,7 +39,7 @@ fun AccountListItem(account: ListedAccountInformation) {
         Column {
             Text(
                 text = account.role.name + " @" + account.userName,
-                color = TextGray,
+                color = Primary,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.SemiBold
             )

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.navigation.navArgument
 import foi.air.szokpt.helpers.LoginHandler
 import foi.air.szokpt.ui.LoginPage
 import foi.air.szokpt.ui.components.AnimatedNavigationBar
+import foi.air.szokpt.views.app.AccountSearchView
 import foi.air.szokpt.views.app.AccountView
 import foi.air.szokpt.views.app.DashboardView
 import foi.air.szokpt.views.app.RegistrationView
@@ -27,7 +28,7 @@ const val ROUTE_REPORTS = "reports"
 const val ROUTE_DAILY_PROCESS = "daily_process"
 const val ROUTE_ACCOUNT = "account"
 const val ROUTE_REGISTRATION = "registration"
-
+const val ROUTE_ALL_ACCOUNT_SEARCH = "all_account_search"
 
 @Composable
 fun MainScreen() {
@@ -72,6 +73,7 @@ fun MainScreen() {
                 val userType = backStackEntry.arguments?.getString("userType") ?: "Unknown"
                 RegistrationView(navController = navController, userType = userType)
             }
+            composable("all_account_search") { AccountSearchView(navController) }
         }
     }
 }

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -45,13 +45,13 @@ fun MainScreen() {
     }
     Scaffold(
         bottomBar = {
-         // if(isAuthenticated.value)
-              AnimatedNavigationBar(navController = navController)
+            if(isAuthenticated.value)
+                AnimatedNavigationBar(navController = navController)
         }
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = "dashboard",
+            startDestination = "login",
             modifier = Modifier.padding(innerPadding)
         ) {
             composable("login") { LoginPage(

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -44,13 +44,13 @@ fun MainScreen() {
     }
     Scaffold(
         bottomBar = {
-          // if(isAuthenticated.value)
+          if(isAuthenticated.value)
               AnimatedNavigationBar(navController = navController)
         }
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = "dashboard",
+            startDestination = "login",
             modifier = Modifier.padding(innerPadding)
         ) {
             composable("login") { LoginPage(

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -44,13 +44,13 @@ fun MainScreen() {
     }
     Scaffold(
         bottomBar = {
-           if(isAuthenticated.value)
-               AnimatedNavigationBar(navController = navController)
+          // if(isAuthenticated.value)
+              AnimatedNavigationBar(navController = navController)
         }
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = "login",
+            startDestination = "dashboard",
             modifier = Modifier.padding(innerPadding)
         ) {
             composable("login") { LoginPage(

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -44,13 +44,13 @@ fun MainScreen() {
     }
     Scaffold(
         bottomBar = {
-          if(isAuthenticated.value)
+         // if(isAuthenticated.value)
               AnimatedNavigationBar(navController = navController)
         }
     ) { innerPadding ->
         NavHost(
             navController = navController,
-            startDestination = "login",
+            startDestination = "dashboard",
             modifier = Modifier.padding(innerPadding)
         ) {
             composable("login") { LoginPage(

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountSearchView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountSearchView.kt
@@ -1,0 +1,145 @@
+package foi.air.szokpt.views.app
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import foi.air.szokpt.models.AccountListRole
+import foi.air.szokpt.models.ListedAccountInformation
+import foi.air.szokpt.ui.components.TileSegment
+import foi.air.szokpt.ui.components.interactible_components.OutlineBouncingButton
+import foi.air.szokpt.ui.components.list_components.AccountListItem
+import foi.air.szokpt.ui.theme.AppBorderRadius
+import foi.air.szokpt.ui.theme.BGLevelOne
+import foi.air.szokpt.ui.theme.BGLevelThree
+import foi.air.szokpt.ui.theme.BGLevelTwo
+import foi.air.szokpt.ui.theme.Primary
+import foi.air.szokpt.ui.theme.Secondary
+import foi.air.szokpt.ui.theme.TextGray
+import foi.air.szokpt.ui.theme.TextWhite
+import foi.air.szokpt.ui.theme.TileSizeMode
+
+
+@Composable
+fun AccountSearchView(navController: NavController){
+    TileSegment(
+        tileSizeMode = TileSizeMode.WRAP_CONTENT,
+        innerPadding = 10.dp,
+        outerMargin = 4.dp,
+        minWidth = 250.dp,
+        minHeight = 20.dp,
+        color = BGLevelOne
+    ) {
+        SearchBarForAccount()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchBarForAccount() {
+    var searchQuery by remember { mutableStateOf("") }
+    var active by remember { mutableStateOf(false) }
+    val allAccounts = listOf(
+        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
+        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
+        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
+        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User),
+        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
+        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
+        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
+        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User)
+    )
+    val filteredAccounts = allAccounts.filter {
+        it.name.contains(searchQuery, ignoreCase = true) ||
+                it.lastName.contains(searchQuery, ignoreCase = true) ||
+                it.userName.contains(searchQuery, ignoreCase = true)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(AppBorderRadius))
+            .heightIn(min = 56.dp, max = 400.dp),
+        contentAlignment = Alignment.TopStart // Align everything to the top
+    ) {
+        SearchBar(
+            query = searchQuery,
+            onQueryChange = { searchQuery = it },
+            onSearch = { /* Handle search submission logic --HERE-- */ },
+            active = active,
+            onActiveChange = { active = it },
+            placeholder = { Text("Search accounts...") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { searchQuery = "" }) {
+                        Icon(Icons.Default.Close, contentDescription = null)
+                    }
+                }
+            },
+            colors = SearchBarDefaults.colors(
+                containerColor = BGLevelTwo,
+                dividerColor = BGLevelThree
+            ),
+            modifier = Modifier
+                .fillMaxWidth() // Ensure it spans the full width - Else ERROR
+        ) {
+            // Display results using AccountListItem composable
+            if (active) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 300.dp)
+                ) {
+                    if (filteredAccounts.isNotEmpty()) {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(8.dp)
+                        ) {
+                            items(filteredAccounts) { account ->
+                                AccountListItem(account = account)
+                            }
+                        }
+                    } else {
+                        Text(
+                            text = "No results found :(",
+                            color = TextGray,
+                            fontSize = 14.sp,
+                            modifier = Modifier.padding(8.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountSearchView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountSearchView.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -52,15 +53,28 @@ import foi.air.szokpt.ui.theme.TileSizeMode
 
 @Composable
 fun AccountSearchView(navController: NavController){
-    TileSegment(
-        tileSizeMode = TileSizeMode.WRAP_CONTENT,
-        innerPadding = 10.dp,
-        outerMargin = 4.dp,
-        minWidth = 250.dp,
-        minHeight = 20.dp,
-        color = BGLevelOne
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
     ) {
-        SearchBarForAccount()
+        Text(
+            modifier = Modifier
+                .padding(16.dp),
+            text = "Search All Accounts",
+            color = TextWhite,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        TileSegment(
+            tileSizeMode = TileSizeMode.WRAP_CONTENT,
+            innerPadding = 0.dp,
+            outerMargin = 8.dp,
+            minWidth = 250.dp,
+            minHeight = 90.dp,
+            color = BGLevelOne
+        ) {
+            SearchBarForAccount()
+        }
     }
 }
 
@@ -81,15 +95,15 @@ fun SearchBarForAccount() {
     )
     val filteredAccounts = allAccounts.filter {
         it.name.contains(searchQuery, ignoreCase = true) ||
-                it.lastName.contains(searchQuery, ignoreCase = true) ||
-                it.userName.contains(searchQuery, ignoreCase = true)
+            it.lastName.contains(searchQuery, ignoreCase = true) ||
+            it.userName.contains(searchQuery, ignoreCase = true)
     }
 
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(AppBorderRadius))
-            .heightIn(min = 56.dp, max = 400.dp),
+            .heightIn(min = 56.dp, max = 900.dp),
         contentAlignment = Alignment.TopStart // Align everything to the top
     ) {
         SearchBar(
@@ -108,8 +122,8 @@ fun SearchBarForAccount() {
                 }
             },
             colors = SearchBarDefaults.colors(
-                containerColor = BGLevelTwo,
-                dividerColor = BGLevelThree
+                containerColor = BGLevelOne,
+                dividerColor = BGLevelTwo
             ),
             modifier = Modifier
                 .fillMaxWidth() // Ensure it spans the full width - Else ERROR
@@ -119,7 +133,7 @@ fun SearchBarForAccount() {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(max = 300.dp)
+                        .heightIn(max = 900.dp)
                 ) {
                     if (filteredAccounts.isNotEmpty()) {
                         LazyColumn(

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -218,13 +218,7 @@ fun AccountList(navController: NavController) {
                     navController.navigate(ROUTE_ACCOUNT)
                 }
             }
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight() // Prevent height overflow
-            ) {
-                SearchBarForAccount()
-            }
+            SearchBarForAccount()
         }
     }
 }
@@ -290,8 +284,8 @@ fun SearchBarForAccount() {
                         }
                     } else {
                         Text(
-                            text = "No results found.",
-                            color = TextWhite.copy(alpha = 0.6f),
+                            text = "No results found :(",
+                            color = TextGray,
                             fontSize = 14.sp
                         )
                     }
@@ -311,6 +305,7 @@ fun AccountListItem(account: ListedAccountInformation) {
                 color = BGLevelThree,
                 shape = RoundedCornerShape(10.dp)
             )
+            .clickable { println("Selected account: $account") } // Forward HERE
             .padding(6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -18,11 +20,16 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -164,8 +171,10 @@ fun RegisterNewAccount(navController: NavController) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountList(navController: NavController) {
+
     TileSegment(
         tileSizeMode = TileSizeMode.WRAP_CONTENT,
         innerPadding = 10.dp,
@@ -174,6 +183,8 @@ fun AccountList(navController: NavController) {
         minHeight = 20.dp,
         color = BGLevelOne
     ) {
+        var active by remember { mutableStateOf(false) }
+
         Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.SpaceBetween
@@ -184,7 +195,7 @@ fun AccountList(navController: NavController) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "List of Accounts",
+                    text = "All Accounts",
                     color = TextWhite,
                     fontSize = 22.sp,
                     fontWeight = FontWeight.SemiBold
@@ -199,21 +210,78 @@ fun AccountList(navController: NavController) {
                     navController.navigate(ROUTE_ACCOUNT)
                 }
             }
-            TileSegment(
-                tileSizeMode = TileSizeMode.FILL_MAX_SIZE,
-                innerPadding = 12.dp,
-                outerMargin = 4.dp,
-                minWidth = 250.dp,
-                minHeight = 20.dp,
-                color = BGLevelTwo
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight() // Prevent height overflow
             ) {
-                Text(
-                    text = "Accounts",
-                    color = TextWhite,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                SearchBarForAccount()
             }
         }
     }
 }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchBarForAccount() {
+    var searchQuery by remember { mutableStateOf("") }
+    var active by remember { mutableStateOf(false) }
+    val allAccounts = listOf("Alice", "Antonio", "Matija", "Bob")
+    val filteredAccounts = allAccounts.filter { it.contains(searchQuery, ignoreCase = true) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp, max = 500.dp)
+    ) {
+        SearchBar(
+            query = searchQuery,
+            onQueryChange = { searchQuery = it },
+            onSearch = { /* Handle search submission logic --HERE-- */},
+            active = active,
+            onActiveChange = { active = it },
+            placeholder = { Text("Search accounts...") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            trailingIcon = {
+                if (searchQuery.isNotEmpty()) {
+                    IconButton(onClick = { searchQuery = "" }) {
+                        Icon(Icons.Default.Close, contentDescription = null)
+                    }
+                }
+            },
+            colors = SearchBarDefaults.colors(
+                containerColor = BGLevelTwo,
+                dividerColor = Color.Transparent
+            ),
+            modifier = Modifier
+                .fillMaxWidth() // Ensure it spans the full width - Else ERROR
+        ) {
+            // Results displayed only when the SearchBar is active
+            if (active) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp)
+                ) {
+                    if (filteredAccounts.isNotEmpty()) {
+                        filteredAccounts.forEach { account ->
+                            Text(
+                                text = account,
+                                color = TextWhite,
+                                fontSize = 14.sp,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = "No results found.",
+                            color = TextWhite.copy(alpha = 0.6f),
+                            fontSize = 14.sp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -17,9 +17,12 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.ArrowForward
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -38,8 +41,10 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import foi.air.szokpt.ui.components.TileSegment
 import foi.air.szokpt.ui.components.interactible_components.FillBouncingButton
+import foi.air.szokpt.ui.components.interactible_components.OutlineBouncingButton
 import foi.air.szokpt.ui.theme.Alternative
 import foi.air.szokpt.ui.theme.BGLevelOne
+import foi.air.szokpt.ui.theme.BGLevelTwo
 import foi.air.szokpt.ui.theme.BGLevelZeroLow
 import foi.air.szokpt.ui.theme.Primary
 import foi.air.szokpt.ui.theme.Secondary
@@ -80,7 +85,7 @@ fun AccountView(navController: NavController){
                 RegisterNewAccount(navController)
             }
             item(span = { GridItemSpan(2) }) {
-                // All accounts list
+                AccountList(navController)
             }
 
         }
@@ -154,6 +159,60 @@ fun RegisterNewAccount(navController: NavController) {
                 ) {
                     navController.navigate(ROUTE_REGISTRATION + "/${options[selectedIndex]}")
                 }
+            }
+        }
+    }
+}
+
+@Composable
+fun AccountList(navController: NavController) {
+    TileSegment(
+        tileSizeMode = TileSizeMode.WRAP_CONTENT,
+        innerPadding = 10.dp,
+        outerMargin = 4.dp,
+        minWidth = 250.dp,
+        minHeight = 20.dp,
+        color = BGLevelOne
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "List of Accounts",
+                    color = TextWhite,
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                OutlineBouncingButton(
+                    modifier = Modifier,
+                    inputText = "",
+                    inputIcon = Icons.AutoMirrored.Rounded.ArrowForward,
+                    contentColor = Primary,
+                    borderColor = Secondary,
+                ) {
+                    navController.navigate(ROUTE_ACCOUNT)
+                }
+            }
+            TileSegment(
+                tileSizeMode = TileSizeMode.FILL_MAX_SIZE,
+                innerPadding = 12.dp,
+                outerMargin = 4.dp,
+                minWidth = 250.dp,
+                minHeight = 20.dp,
+                color = BGLevelTwo
+            ) {
+                Text(
+                    text = "Accounts",
+                    color = TextWhite,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium
+                )
             }
         }
     }

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -219,7 +219,6 @@ fun AccountList(navController: NavController) {
                     contentColor = Primary,
                     borderColor = Secondary,
                 ) {
-                    navController.navigate(ROUTE_ACCOUNT)
                 }
             }
             SearchBarForAccount()

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -187,7 +187,6 @@ fun RegisterNewAccount(navController: NavController) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AccountList(navController: NavController) {
-
     TileSegment(
         tileSizeMode = TileSizeMode.WRAP_CONTENT,
         innerPadding = 10.dp,
@@ -220,89 +219,10 @@ fun AccountList(navController: NavController) {
                     contentColor = Primary,
                     borderColor = Secondary,
                 ) {
-                }
-            }
-            SearchBarForAccount()
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun SearchBarForAccount() {
-    var searchQuery by remember { mutableStateOf("") }
-    var active by remember { mutableStateOf(false) }
-    val allAccounts = listOf(
-        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
-        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
-        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
-        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User),
-        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
-        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
-        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
-        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User)
-    )
-    val filteredAccounts = allAccounts.filter {
-        it.name.contains(searchQuery, ignoreCase = true) ||
-                it.lastName.contains(searchQuery, ignoreCase = true) ||
-                it.userName.contains(searchQuery, ignoreCase = true)
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(AppBorderRadius))
-            .heightIn(min = 56.dp, max = 400.dp),
-        contentAlignment = Alignment.TopStart // Align everything to the top
-    ) {
-        SearchBar(
-            query = searchQuery,
-            onQueryChange = { searchQuery = it },
-            onSearch = { /* Handle search submission logic --HERE-- */ },
-            active = active,
-            onActiveChange = { active = it },
-            placeholder = { Text("Search accounts...") },
-            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-            trailingIcon = {
-                if (searchQuery.isNotEmpty()) {
-                    IconButton(onClick = { searchQuery = "" }) {
-                        Icon(Icons.Default.Close, contentDescription = null)
-                    }
-                }
-            },
-            colors = SearchBarDefaults.colors(
-                containerColor = BGLevelTwo,
-                dividerColor = BGLevelThree
-            ),
-            modifier = Modifier
-                .fillMaxWidth() // Ensure it spans the full width - Else ERROR
-        ) {
-            // Display results using AccountListItem composable
-            if (active) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 300.dp)
-                ) {
-                    if (filteredAccounts.isNotEmpty()) {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(8.dp)
-                        ) {
-                            items(filteredAccounts) { account ->
-                                AccountListItem(account = account)
-                            }
-                        }
-                    } else {
-                        Text(
-                            text = "No results found :(",
-                            color = TextGray,
-                            fontSize = 14.sp,
-                            modifier = Modifier.padding(8.dp)
-                        )
-                    }
+                    navController.navigate(ROUTE_DAILY_PROCESS)
                 }
             }
         }
     }
 }
+

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.ArrowForward
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -72,6 +73,7 @@ import foi.air.szokpt.ui.theme.TextGray
 import foi.air.szokpt.ui.theme.TextWhite
 import foi.air.szokpt.ui.theme.TileSizeMode
 import foi.air.szokpt.views.ROUTE_ACCOUNT
+import foi.air.szokpt.views.ROUTE_ALL_ACCOUNT_SEARCH
 import foi.air.szokpt.views.ROUTE_DAILY_PROCESS
 import foi.air.szokpt.views.ROUTE_REGISTRATION
 
@@ -99,15 +101,11 @@ fun AccountView(navController: NavController){
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ){
             item(span = { GridItemSpan(2) }) {
-                // Search
-            }
-            item(span = { GridItemSpan(2) }) {
                 RegisterNewAccount(navController)
             }
             item(span = { GridItemSpan(2) }) {
                 AccountList(navController)
             }
-
         }
     }
 }
@@ -215,11 +213,11 @@ fun AccountList(navController: NavController) {
                 OutlineBouncingButton(
                     modifier = Modifier,
                     inputText = "",
-                    inputIcon = Icons.AutoMirrored.Rounded.ArrowForward,
+                    inputIcon = Icons.Rounded.Search,
                     contentColor = Primary,
                     borderColor = Secondary,
                 ) {
-                    navController.navigate(ROUTE_DAILY_PROCESS)
+                    navController.navigate(ROUTE_ALL_ACCOUNT_SEARCH)
                 }
             }
         }

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -58,6 +58,7 @@ import foi.air.szokpt.models.Transaction
 import foi.air.szokpt.ui.components.TileSegment
 import foi.air.szokpt.ui.components.interactible_components.FillBouncingButton
 import foi.air.szokpt.ui.components.interactible_components.OutlineBouncingButton
+import foi.air.szokpt.ui.components.list_components.AccountListItem
 import foi.air.szokpt.ui.components.transaction_components.TransactionIcon
 import foi.air.szokpt.ui.theme.Alternative
 import foi.air.szokpt.ui.theme.AppBorderRadius
@@ -305,34 +306,3 @@ fun SearchBarForAccount() {
         }
     }
 }
-
-@Composable
-fun AccountListItem(account: ListedAccountInformation) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp, horizontal = 6.dp)
-            .background(
-                color = BGLevelThree,
-                shape = RoundedCornerShape(10.dp)
-            )
-            .clickable { println("Selected account: $account") } // Forward HERE
-            .padding(6.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column {
-            Text(
-                text = account.role.name + " @" + account.userName,
-                color = TextGray,
-                fontSize = 12.sp,
-                fontWeight = FontWeight.SemiBold
-            )
-            Text(
-                text = "${account.name} ${account.lastName}",
-                color = TextWhite,
-                fontSize = 16.sp
-            )
-        }
-    }
-}
-

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
@@ -45,6 +46,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -58,6 +60,7 @@ import foi.air.szokpt.ui.components.interactible_components.FillBouncingButton
 import foi.air.szokpt.ui.components.interactible_components.OutlineBouncingButton
 import foi.air.szokpt.ui.components.transaction_components.TransactionIcon
 import foi.air.szokpt.ui.theme.Alternative
+import foi.air.szokpt.ui.theme.AppBorderRadius
 import foi.air.szokpt.ui.theme.BGLevelOne
 import foi.air.szokpt.ui.theme.BGLevelThree
 import foi.air.szokpt.ui.theme.BGLevelTwo
@@ -192,8 +195,6 @@ fun AccountList(navController: NavController) {
         minHeight = 20.dp,
         color = BGLevelOne
     ) {
-        var active by remember { mutableStateOf(false) }
-
         Column(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.SpaceBetween
@@ -248,7 +249,9 @@ fun SearchBarForAccount() {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 56.dp, max = 400.dp)
+            .clip(RoundedCornerShape(AppBorderRadius))
+            .heightIn(min = 56.dp, max = 400.dp),
+        contentAlignment = Alignment.TopStart // Align everything to the top
     ) {
         SearchBar(
             query = searchQuery,
@@ -279,7 +282,6 @@ fun SearchBarForAccount() {
                         .fillMaxWidth()
                         .heightIn(max = 300.dp)
                 ) {
-                    
                     if (filteredAccounts.isNotEmpty()) {
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.filled.Close
@@ -47,11 +49,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import foi.air.szokpt.models.ListedAccountInformation
+import foi.air.szokpt.models.Transaction
 import foi.air.szokpt.ui.components.TileSegment
 import foi.air.szokpt.ui.components.interactible_components.FillBouncingButton
 import foi.air.szokpt.ui.components.interactible_components.OutlineBouncingButton
+import foi.air.szokpt.ui.components.transaction_components.TransactionIcon
 import foi.air.szokpt.ui.theme.Alternative
 import foi.air.szokpt.ui.theme.BGLevelOne
+import foi.air.szokpt.ui.theme.BGLevelThree
 import foi.air.szokpt.ui.theme.BGLevelTwo
 import foi.air.szokpt.ui.theme.BGLevelZeroLow
 import foi.air.szokpt.ui.theme.Primary
@@ -252,7 +258,7 @@ fun SearchBarForAccount() {
             },
             colors = SearchBarDefaults.colors(
                 containerColor = BGLevelTwo,
-                dividerColor = Color.Transparent
+                dividerColor = BGLevelThree
             ),
             modifier = Modifier
                 .fillMaxWidth() // Ensure it spans the full width - Else ERROR
@@ -288,4 +294,32 @@ fun SearchBarForAccount() {
     }
 }
 
+@Composable
+fun AccountListItem(account: ListedAccountInformation) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp, horizontal = 6.dp)
+            .background(
+                color = BGLevelThree,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column {
+            Text(
+                text = account.role.name + " @" + account.userName,
+                color = TextGray,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "${account.name} ${account.lastName}",
+                color = Color.Gray,
+                fontSize = 16.sp
+            )
+        }
+    }
+}
 

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import foi.air.szokpt.models.AccountListRole
 import foi.air.szokpt.models.ListedAccountInformation
 import foi.air.szokpt.models.Transaction
 import foi.air.szokpt.ui.components.TileSegment
@@ -233,8 +234,21 @@ fun AccountList(navController: NavController) {
 fun SearchBarForAccount() {
     var searchQuery by remember { mutableStateOf("") }
     var active by remember { mutableStateOf(false) }
-    val allAccounts = listOf("Alice", "Antonio", "Matija", "Bob")
-    val filteredAccounts = allAccounts.filter { it.contains(searchQuery, ignoreCase = true) }
+    val allAccounts = listOf(
+        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
+        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
+        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
+        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User),
+        ListedAccountInformation("Alice", "Bob", "abob", AccountListRole.User),
+        ListedAccountInformation("Antonio", "Testic", "test", AccountListRole.Admin),
+        ListedAccountInformation("Matija", "Rosevelt", "mmatija", AccountListRole.User),
+        ListedAccountInformation("Bob", "Taylor", "btaylor", AccountListRole.User)
+    )
+    val filteredAccounts = allAccounts.filter {
+        it.name.contains(searchQuery, ignoreCase = true) ||
+                it.lastName.contains(searchQuery, ignoreCase = true) ||
+                it.userName.contains(searchQuery, ignoreCase = true)
+    }
 
     Box(
         modifier = Modifier
@@ -263,7 +277,7 @@ fun SearchBarForAccount() {
             modifier = Modifier
                 .fillMaxWidth() // Ensure it spans the full width - Else ERROR
         ) {
-            // Results displayed only when the SearchBar is active
+            // Display results using AccountListItem composable
             if (active) {
                 Column(
                     modifier = Modifier
@@ -272,14 +286,7 @@ fun SearchBarForAccount() {
                 ) {
                     if (filteredAccounts.isNotEmpty()) {
                         filteredAccounts.forEach { account ->
-                            Text(
-                                text = account,
-                                color = TextWhite,
-                                fontSize = 14.sp,
-                                modifier = Modifier
-                                    .padding(vertical = 4.dp)
-                                    .clickable { println("Selected account: $account") }
-                            )
+                            AccountListItem(account = account)
                         }
                     } else {
                         Text(
@@ -304,7 +311,7 @@ fun AccountListItem(account: ListedAccountInformation) {
                 color = BGLevelThree,
                 shape = RoundedCornerShape(10.dp)
             )
-            .padding(12.dp),
+            .padding(6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column {
@@ -316,7 +323,7 @@ fun AccountListItem(account: ListedAccountInformation) {
             )
             Text(
                 text = "${account.name} ${account.lastName}",
-                color = Color.Gray,
+                color = TextWhite,
                 fontSize = 16.sp
             )
         }

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -210,6 +210,8 @@ fun AccountList(navController: NavController) {
                     fontSize = 22.sp,
                     fontWeight = FontWeight.SemiBold
                 )
+                // TODO: Implement a route to just show a newly created singular account list view
+                //       Called AcccountListView. Where i can only view and search all accounts.
                 OutlineBouncingButton(
                     modifier = Modifier,
                     inputText = "",

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -273,20 +274,27 @@ fun SearchBarForAccount() {
         ) {
             // Display results using AccountListItem composable
             if (active) {
-                Column(
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(8.dp)
+                        .heightIn(max = 300.dp)
                 ) {
+                    
                     if (filteredAccounts.isNotEmpty()) {
-                        filteredAccounts.forEach { account ->
-                            AccountListItem(account = account)
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding = PaddingValues(8.dp)
+                        ) {
+                            items(filteredAccounts) { account ->
+                                AccountListItem(account = account)
+                            }
                         }
                     } else {
                         Text(
                             text = "No results found :(",
                             color = TextGray,
-                            fontSize = 14.sp
+                            fontSize = 14.sp,
+                            modifier = Modifier.padding(8.dp)
                         )
                     }
                 }

--- a/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/AccountView.kt
@@ -1,6 +1,7 @@
 package foi.air.szokpt.views.app
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -232,12 +233,12 @@ fun SearchBarForAccount() {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .heightIn(min = 56.dp, max = 500.dp)
+            .heightIn(min = 56.dp, max = 400.dp)
     ) {
         SearchBar(
             query = searchQuery,
             onQueryChange = { searchQuery = it },
-            onSearch = { /* Handle search submission logic --HERE-- */},
+            onSearch = { /* Handle search submission logic --HERE-- */ },
             active = active,
             onActiveChange = { active = it },
             placeholder = { Text("Search accounts...") },
@@ -269,7 +270,9 @@ fun SearchBarForAccount() {
                                 text = account,
                                 color = TextWhite,
                                 fontSize = 14.sp,
-                                modifier = Modifier.padding(vertical = 4.dp)
+                                modifier = Modifier
+                                    .padding(vertical = 4.dp)
+                                    .clickable { println("Selected account: $account") }
                             )
                         }
                     } else {
@@ -284,4 +287,5 @@ fun SearchBarForAccount() {
         }
     }
 }
+
 


### PR DESCRIPTION
Trenutno je implementirano kao mock uz upotrebu ListedAccountInformation (pod models) za bolji i pregledniji prikaz uz upotrebu AccountListItem composable koja prima argument tipa ListedAccountInformation za bolji prikaz unutar rezultata kod SearchBarForAccount unutar novog TileSegment-a koji je dodani u AccountView pogled.

SearchBarForAccount prikazuje uređenu SearchBar composable M3 komponentu.

Rezultati pretraživanja su clickable za daljnje prosljeđivanje informacija drugim pogledima.

Potrebno bi bilo dodati i ikonu na desnu stranu AccountListItem da se korisniku sugerira da je rezultat u mogućnosti biti pritisnuti.