### PR TITLE
Promjena identifikatora transakcije s id na guid

### DIFF
--- a/app/src/main/java/foi/air/szokpt/helpers/TransactionDetailsHandler.kt
+++ b/app/src/main/java/foi/air/szokpt/helpers/TransactionDetailsHandler.kt
@@ -7,13 +7,14 @@ import hr.foi.air.szokpt.core.transactions.TransactionData
 import hr.foi.air.szokpt.core.transactions.TransactionDetailsOutcomeListener
 import hr.foi.air.szokpt.ws.models.responses.Transaction
 import hr.foi.air.szokpt.ws.request_handlers.TransactionDetailsRequestHandler
+import java.util.UUID
 
 class TransactionDetailsHandler() {
     fun getTransactionDetails(
-        transactionId: Int,
+        transactionGuid: UUID,
         transactionDetailsListener: TransactionDetailsOutcomeListener
     ) {
-        val transactionDetailsRequestHandler = TransactionDetailsRequestHandler(transactionId)
+        val transactionDetailsRequestHandler = TransactionDetailsRequestHandler(transactionGuid)
 
         transactionDetailsRequestHandler.sendRequest(
             object : ResponseListener<Transaction> {
@@ -22,7 +23,7 @@ class TransactionDetailsHandler() {
                     if (transaction != null) {
                         transactionDetailsListener.onSuccessfulTransactionDetailsFetch(
                             transactionData = TransactionData(
-                                id = transaction.id,
+                                guid = transaction.guid,
                                 amount = transaction.amount,
                                 currency = transaction.currency,
                                 trxType = transaction.trxType,
@@ -33,6 +34,7 @@ class TransactionDetailsHandler() {
                                 maskedPan = transaction.maskedPan,
                                 pinUsed = transaction.pinUsed,
                                 responseCode = transaction.responseCode,
+                                approvalCode = transaction.approvalCode,
                                 processed = transaction.processed
                             )
                         )

--- a/app/src/main/java/foi/air/szokpt/helpers/TransactionUtils.kt
+++ b/app/src/main/java/foi/air/szokpt/helpers/TransactionUtils.kt
@@ -28,11 +28,11 @@ object TransactionUtils {
     )
 
     fun getCardBrandDrawable(cardBrand: String): Int = when (cardBrand) {
-        "Maestro" -> R.drawable.maestro
-        "Visa" -> R.drawable.visa
-        "MasterCard" -> R.drawable.mastercard
-        "Diners" -> R.drawable.diners
-        "Discover" -> R.drawable.discover
+        "MAESTRO" -> R.drawable.maestro
+        "VISA" -> R.drawable.visa
+        "MASTERCARD" -> R.drawable.mastercard
+        "DIBERS" -> R.drawable.diners
+        "DISCOVER" -> R.drawable.discover
         else -> R.drawable.logo
     }
 }

--- a/app/src/main/java/foi/air/szokpt/viewmodels/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/foi/air/szokpt/viewmodels/TransactionDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import foi.air.szokpt.helpers.TransactionDetailsHandler
 import hr.foi.air.szokpt.core.transactions.TransactionData
 import hr.foi.air.szokpt.core.transactions.TransactionDetailsOutcomeListener
+import java.util.UUID
 
 class TransactionDetailsViewModel : ViewModel() {
     private val _errorMessage = MutableLiveData<String?>(null)
@@ -16,9 +17,9 @@ class TransactionDetailsViewModel : ViewModel() {
     private val transactionDetailsHandler = TransactionDetailsHandler()
 
     fun fetchTransactionDetails(
-        transactionId: Int,
+        transactionGuid: UUID,
     ) {
-        transactionDetailsHandler.getTransactionDetails(transactionId, object :
+        transactionDetailsHandler.getTransactionDetails(transactionGuid, object :
             TransactionDetailsOutcomeListener {
             override fun onSuccessfulTransactionDetailsFetch(transactionData: TransactionData) {
                 _transactionData.value = transactionData

--- a/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
+++ b/app/src/main/java/foi/air/szokpt/views/MainScreen.kt
@@ -25,6 +25,7 @@ import foi.air.szokpt.views.app.TransactionsView
 import foi.air.szokpt.views.test_views.DailyProcessScreen
 import hr.foi.air.szokpt.ws.models.responses.User
 import java.nio.charset.StandardCharsets
+import java.util.UUID
 
 const val ROUTE_DASHBOARD = "dashboard"
 const val ROUTE_REPORTS = "reports"
@@ -100,15 +101,15 @@ fun MainScreen() {
             }
 
             composable(
-                route = "transaction_details/{transactionId}",
-                arguments = listOf(navArgument("transactionId") { type = NavType.IntType })
+                route = "transaction_details/{transactionGuid}",
+                arguments = listOf(navArgument("transactionGuid") { type = NavType.StringType })
             ) { backStackEntry ->
-                val transactionId =
-                    backStackEntry.arguments?.getInt("transactionId") ?: return@composable
-
+                val transactionGuidString = backStackEntry.arguments?.getString("transactionGuid")
+                val transactionGuid = transactionGuidString?.let { UUID.fromString(it) }
+                    ?: return@composable
                 TransactionDetailsView(
                     navController = navController,
-                    transactionId = transactionId
+                    transactionGuid = transactionGuid
                 )
             }
         }

--- a/app/src/main/java/foi/air/szokpt/views/app/TransactionDetailsView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/TransactionDetailsView.kt
@@ -38,17 +38,18 @@ import foi.air.szokpt.ui.theme.Primary
 import foi.air.szokpt.ui.theme.TextWhite
 import foi.air.szokpt.ui.theme.TileSizeMode
 import foi.air.szokpt.viewmodels.TransactionDetailsViewModel
+import java.util.UUID
 
 @Composable
 fun TransactionDetailsView(
     navController: NavController,
-    transactionId: Int,
+    transactionGuid: UUID,
     viewModel: TransactionDetailsViewModel = viewModel()
 ) {
     val transaction by viewModel.transactionData.observeAsState()
     val errorMessage by viewModel.errorMessage.observeAsState()
 
-    viewModel.fetchTransactionDetails(transactionId = transactionId)
+    viewModel.fetchTransactionDetails(transactionGuid = transactionGuid)
 
     Column(modifier = Modifier.fillMaxSize()) {
         Text(
@@ -131,7 +132,7 @@ fun TransactionDetailsView(
                                             .padding(horizontal = 12.dp, vertical = 8.dp)
                                     ) {
                                         Text(
-                                            text = "Transaction #${transaction!!.id}",
+                                            text = "Transaction #${transaction!!.guid}",
                                             color = Primary,
                                             fontWeight = FontWeight.SemiBold,
                                             fontSize = 18.sp

--- a/app/src/main/java/foi/air/szokpt/views/app/TransactionsView.kt
+++ b/app/src/main/java/foi/air/szokpt/views/app/TransactionsView.kt
@@ -102,7 +102,7 @@ fun TransactionsView(navController: NavController) {
                     TransactionItem(
                         transaction = transaction,
                         onClick = {
-                            navController.navigate("transaction_details/${transaction.id}")
+                            navController.navigate("transaction_details/${transaction.guid}")
                         }
                     )
                 }

--- a/core/src/main/java/hr/foi/air/szokpt/core/transactions/TransactionData.kt
+++ b/core/src/main/java/hr/foi/air/szokpt/core/transactions/TransactionData.kt
@@ -1,7 +1,9 @@
 package hr.foi.air.szokpt.core.transactions
 
+import java.util.UUID
+
 data class TransactionData(
-    val id: Int,
+    val guid: UUID,
     val amount: Double,
     val currency: String,
     val trxType: String,
@@ -12,5 +14,6 @@ data class TransactionData(
     val maskedPan: String,
     val pinUsed: Boolean,
     val responseCode: String,
+    val approvalCode: String,
     val processed: Boolean
 )

--- a/ws/src/main/java/hr/foi/air/szokpt/ws/models/responses/Transaction.kt
+++ b/ws/src/main/java/hr/foi/air/szokpt/ws/models/responses/Transaction.kt
@@ -1,18 +1,20 @@
 package hr.foi.air.szokpt.ws.models.responses
 
 import com.google.gson.annotations.SerializedName
+import java.util.UUID
 
 data class Transaction(
-    @SerializedName("id") val id: Int,
+    @SerializedName("guid") val guid: UUID,
     @SerializedName("amount") val amount: Double,
     @SerializedName("currency") val currency: String,
-    @SerializedName("trxType") val trxType: String,
-    @SerializedName("installmentsNumber") val installmentsNumber: Int,
-    @SerializedName("installmentsCreditor") val installmentsCreditor: String,
-    @SerializedName("cardBrand") val cardBrand: String,
-    @SerializedName("transactionTimestamp") val transactionTimestamp: String,
-    @SerializedName("maskedPan") val maskedPan: String,
-    @SerializedName("pinUsed") val pinUsed: Boolean,
-    @SerializedName("responseCode") val responseCode: String,
+    @SerializedName("trx_type") val trxType: String,
+    @SerializedName("installments_number") val installmentsNumber: Int,
+    @SerializedName("installments_creditor") val installmentsCreditor: String,
+    @SerializedName("card_brand") val cardBrand: String,
+    @SerializedName("transaction_timestamp") val transactionTimestamp: String,
+    @SerializedName("masked_pan") val maskedPan: String,
+    @SerializedName("pin_used") val pinUsed: Boolean,
+    @SerializedName("response_code") val responseCode: String,
+    @SerializedName("approval_code") val approvalCode: String,
     @SerializedName("processed") val processed: Boolean
 )

--- a/ws/src/main/java/hr/foi/air/szokpt/ws/network/TransactionsService.kt
+++ b/ws/src/main/java/hr/foi/air/szokpt/ws/network/TransactionsService.kt
@@ -8,6 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
+import java.util.UUID
 
 interface TransactionsService {
     @GET("transactions")
@@ -22,8 +23,8 @@ interface TransactionsService {
         @Query("amount_less_than") maxAmount: Int?,
     ): Call<SuccessfulResponseBody<TransactionPageResponse>>
 
-    @GET("transactions/{id}")
+    @GET("transactions/{guid}")
     fun getTransactionDetails(
-        @Path("id") transactionId: Int
+        @Path("guid") transactionGuid: UUID
     ): Call<SuccessfulResponseBody<Transaction>>
 }

--- a/ws/src/main/java/hr/foi/air/szokpt/ws/request_handlers/TransactionDetailsRequestHandler.kt
+++ b/ws/src/main/java/hr/foi/air/szokpt/ws/request_handlers/TransactionDetailsRequestHandler.kt
@@ -4,12 +4,13 @@ import NetworkService
 import hr.foi.air.szokpt.core.network.models.SuccessfulResponseBody
 import hr.foi.air.szokpt.ws.models.responses.Transaction
 import retrofit2.Call
+import java.util.UUID
 
 class TransactionDetailsRequestHandler(
-    private val transactionId: Int,
+    private val transactionGuid: UUID,
 ) : TemplateRequestHandler<Transaction>() {
     override fun getServiceCall(): Call<SuccessfulResponseBody<Transaction>> {
         val service = NetworkService.transactionsService
-        return service.getTransactionDetails(transactionId)
+        return service.getTransactionDetails(transactionGuid)
     }
 }


### PR DESCRIPTION
Promijenjene su podatkovne klase tako da sadržavaju guid umjesto id. Enumeracija CardBrand je promijenjena u skladu s istom enumeracijom na backand-u. U promijenjena su sva korištenja transaction.id u transaction.guid.